### PR TITLE
Add Jest tests for key components

### DIFF
--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -1,6 +1,6 @@
 The project runs with `node 18`. 
 
-After running `npm -i` you'll need to make two manual changes:
+After running `npm install` you'll need to make two manual changes:
 
 ## postprocess
 postprocess is used in rollup.config.js.
@@ -30,15 +30,3 @@ More info here: https://github.com/developit/rollup-plugin-postprocess/issues/10
       "default": "./plugins/ryb.mjs"
     }
 ```
-
-## Running Tests and Contributing to Test Development
-
-To run the Jest tests for the Excalidraw plugin, use the following command:
-
-```bash
-npm run test
-```
-
-This will execute all tests located in the `__tests__` directory and generate a coverage report. To contribute to test development, ensure you have a thorough understanding of the Excalidraw plugin's functionality and the Jest testing framework. Write tests that cover a wide range of scenarios, including edge cases, to ensure the robustness of the plugin's key components.
-
-For more information on test coverage and our testing philosophy, refer to the project's documentation on GitHub.

--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -30,3 +30,15 @@ More info here: https://github.com/developit/rollup-plugin-postprocess/issues/10
       "default": "./plugins/ryb.mjs"
     }
 ```
+
+## Running Tests and Contributing to Test Development
+
+To run the Jest tests for the Excalidraw plugin, use the following command:
+
+```bash
+npm run test
+```
+
+This will execute all tests located in the `__tests__` directory and generate a coverage report. To contribute to test development, ensure you have a thorough understanding of the Excalidraw plugin's functionality and the Jest testing framework. Write tests that cover a wide range of scenarios, including edge cases, to ensure the robustness of the plugin's key components.
+
+For more information on test coverage and our testing philosophy, refer to the project's documentation on GitHub.

--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,0 +1,41 @@
+// This file is a mock implementation of the Obsidian API for Jest testing
+// It simulates the Obsidian environment for ExcalidrawAutomate, ExcalidrawView, and ExcalidrawData components
+
+const mockVault = {
+  getAbstractFileByPath: jest.fn(),
+  read: jest.fn(),
+  create: jest.fn(),
+  modify: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockMetadataCache = {
+  getCache: jest.fn(),
+  on: jest.fn(),
+};
+
+const mockWorkspace = {
+  getActiveFile: jest.fn(),
+  onLayoutReady: jest.fn(),
+  on: jest.fn(),
+};
+
+const mockApp = {
+  vault: mockVault,
+  metadataCache: mockMetadataCache,
+  workspace: mockWorkspace,
+  plugins: {
+    plugins: {
+      "obsidian-excalidraw-plugin": {
+        getExcalidrawAPI: jest.fn(),
+      },
+    },
+  },
+};
+
+module.exports = {
+  Vault: jest.fn(() => mockVault),
+  MetadataCache: jest.fn(() => mockMetadataCache),
+  Workspace: jest.fn(() => mockWorkspace),
+  App: jest.fn(() => mockApp),
+};

--- a/__tests__/ExcalidrawAutomate.test.ts
+++ b/__tests__/ExcalidrawAutomate.test.ts
@@ -1,0 +1,56 @@
+import { ExcalidrawAutomate } from "../src/ExcalidrawAutomate";
+import { mockApp, mockVault, mockMetadataCache, mockWorkspace } from "../__mocks__/obsidian";
+
+describe("ExcalidrawAutomate", () => {
+  let ea: ExcalidrawAutomate;
+
+  beforeEach(() => {
+    // Setup mock Obsidian environment
+    global.app = mockApp;
+    global.app.vault = mockVault;
+    global.app.metadataCache = mockMetadataCache;
+    global.app.workspace = mockWorkspace;
+
+    ea = new ExcalidrawAutomate(mockApp.plugins.plugins["obsidian-excalidraw-plugin"]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("File handling functionalities", () => {
+    test("should create a new Excalidraw drawing", async () => {
+      const filename = "test.excalidraw";
+      const foldername = "Drawings";
+      const content = "mock content";
+
+      await ea.create({ filename, foldername, plaintext: content });
+
+      expect(mockVault.create).toHaveBeenCalledWith(expect.stringContaining(foldername + "/" + filename), expect.stringContaining(content));
+    });
+
+    // Additional tests for file handling functionalities
+  });
+
+  describe("Drawing functionalities", () => {
+    test("should add a rectangle to the drawing", () => {
+      ea.addRect(0, 0, 100, 100);
+
+      const elements = ea.getElements();
+      expect(elements).toHaveLength(1);
+      expect(elements[0].type).toBe("rectangle");
+    });
+
+    // Additional tests for drawing functionalities
+  });
+
+  describe("Error handling and edge cases", () => {
+    test("should handle non-existent plugin gracefully", () => {
+      const ea = new ExcalidrawAutomate(undefined);
+
+      expect(() => ea.addRect(0, 0, 100, 100)).not.toThrow();
+    });
+
+    // Additional tests for error handling and edge cases
+  });
+});

--- a/__tests__/ExcalidrawData.test.ts
+++ b/__tests__/ExcalidrawData.test.ts
@@ -1,0 +1,60 @@
+import { ExcalidrawData } from "../src/ExcalidrawData";
+import { App, TFile } from "obsidian";
+import { mocked } from "ts-jest/utils";
+
+// Mocking the Obsidian API and ExcalidrawData dependencies
+jest.mock("obsidian");
+jest.mock("../src/ExcalidrawData");
+
+describe("ExcalidrawData", () => {
+  let data: ExcalidrawData;
+  let app: App;
+  let file: TFile;
+
+  beforeEach(() => {
+    app = new App();
+    file = new TFile();
+    data = new ExcalidrawData(app, file);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("loadData", () => {
+    it("should load data correctly", async () => {
+      const mockData = '{"elements": [], "appState": {}}';
+      mocked(app.vault.read).mockResolvedValue(mockData);
+
+      await data.loadData(file);
+
+      expect(app.vault.read).toHaveBeenCalledWith(file);
+      expect(data.scene).toEqual(JSON.parse(mockData));
+    });
+
+    it("should handle file read errors gracefully", async () => {
+      mocked(app.vault.read).mockRejectedValue(new Error("File read error"));
+
+      await expect(data.loadData(file)).rejects.toThrow("File read error");
+    });
+  });
+
+  describe("saveData", () => {
+    it("should save data correctly", async () => {
+      const mockData = '{"elements": [], "appState": {}}';
+      data.scene = JSON.parse(mockData);
+
+      await data.saveData();
+
+      expect(app.vault.modify).toHaveBeenCalledWith(file, mockData);
+    });
+
+    it("should handle file write errors gracefully", async () => {
+      mocked(app.vault.modify).mockRejectedValue(new Error("File write error"));
+
+      await expect(data.saveData()).rejects.toThrow("File write error");
+    });
+  });
+
+  // Additional tests for error handling, data integrity, etc.
+});

--- a/__tests__/ExcalidrawView.test.ts
+++ b/__tests__/ExcalidrawView.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import ExcalidrawView from '../src/ExcalidrawView';
+import { ExcalidrawAutomate } from '../src/ExcalidrawAutomate';
+import { mockObsidian } from './__mocks__/obsidian';
+
+jest.mock('../src/ExcalidrawView');
+jest.mock('../src/ExcalidrawAutomate');
+
+describe('ExcalidrawView', () => {
+  beforeEach(() => {
+    // Setup mock for Obsidian API
+    mockObsidian();
+  });
+
+  it('should toggle view mode correctly', () => {
+    const view = new ExcalidrawView();
+    const automate = new ExcalidrawAutomate();
+
+    // Mock implementation for view mode toggling
+    view.toggleViewMode = jest.fn();
+
+    // Simulate toggling view mode
+    automate.toggleViewMode(view);
+
+    // Expect view mode toggle to have been called
+    expect(view.toggleViewMode).toHaveBeenCalled();
+  });
+
+  it('should handle element selection correctly', () => {
+    const view = new ExcalidrawView();
+    const automate = new ExcalidrawAutomate();
+
+    // Mock implementation for element selection
+    view.selectElement = jest.fn();
+
+    // Simulate selecting an element
+    automate.selectElement(view, 'element-id');
+
+    // Expect element to be selected
+    expect(view.selectElement).toHaveBeenCalledWith('element-id');
+  });
+
+  it('should update drawing correctly', () => {
+    const view = new ExcalidrawView();
+    const automate = new ExcalidrawAutomate();
+
+    // Mock implementation for drawing updates
+    view.updateDrawing = jest.fn();
+
+    // Simulate updating drawing
+    automate.updateDrawing(view, []);
+
+    // Expect drawing to be updated
+    expect(view.updateDrawing).toHaveBeenCalledWith([]);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/__mocks__/obsidian.ts'],
+  moduleNameMapper: {
+    '^obsidian$': '<rootDir>/__mocks__/obsidian.ts',
+  },
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "build": "cross-env NODE_ENV=production rollup --config rollup.config.js",
     "lib": "cross-env NODE_ENV=lib rollup --config rollup.config.js",
     "code:fix": "eslint --max-warnings=0 --ext .ts,.tsx ./src --fix",
-    "madge": "madge --circular ."
+    "madge": "madge --circular .",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -56,6 +59,8 @@
     "cssnano": "^6.0.2",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "lz-string": "^1.5.0",
     "obsidian": "^1.4.0",
     "prettier": "^3.0.1",


### PR DESCRIPTION
Related to #1

Adds Jest testing framework setup and initial tests for the obsidian-excalidraw-plugin, focusing on ExcalidrawAutomate, ExcalidrawView, and ExcalidrawData components.

- **Jest Configuration**: Implements a Jest configuration file (`jest.config.js`) to support TypeScript, simulate the Obsidian plugin environment, and define coverage reporting.
- **Mock Obsidian API**: Introduces a mock implementation of the Obsidian API (`__mocks__/obsidian.ts`) to facilitate testing of plugin components without the need for an actual Obsidian environment.
- **Component Tests**: Adds test files for ExcalidrawAutomate (`__tests__/ExcalidrawAutomate.test.ts`), ExcalidrawView (`__tests__/ExcalidrawView.test.ts`), and ExcalidrawData (`__tests__/ExcalidrawData.test.ts`), covering functionalities such as file handling, drawing operations, and data management.
- **Package.json Updates**: Updates `package.json` to include Jest and ts-jest as development dependencies and adds scripts for running tests and generating coverage reports.
- **Documentation**: Modifies `README-BUILD.md` to include instructions for running tests and contributing to test development, along with information on test coverage and testing philosophy.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lightningRalf/obsidian-excalidraw-plugin/issues/1?shareId=53090a6a-b9b3-490b-bca8-8a7ac1bede69).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated `README-BUILD.md` with instructions for manual changes post `npm -i` and guidelines for running and contributing to tests using Jest.

- **New Features**
  - Introduced Jest testing capabilities with scripts for running tests, watching tests, and generating coverage reports in `package.json`.

- **Tests**
  - Added comprehensive test cases for `ExcalidrawAutomate`, `ExcalidrawData`, and `ExcalidrawView` classes.
  - Configured Jest for TypeScript testing in `jest.config.js`.
  - Implemented mocks for the Obsidian API to facilitate testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->