### PR TITLE
Update tests to align with revised obsidian.ts mocks

### DIFF
--- a/__mocks__/obsidian/App.ts
+++ b/__mocks__/obsidian/App.ts
@@ -22,4 +22,18 @@ export class AppMock implements App {
 	get lastEvent(): UserEvent | null {
 		throw new Error("Not implemented.");
 	}
+	get internalPlugins(): any {
+		throw new Error("Not implemented.");
+	}
+	isMobile(): boolean {
+		throw new Error("Not implemented.");
+	}
+	getObsidianUrl(file: TFile): string {
+		throw new Error("Not implemented.");
+	}
+	metadataTypeManager: {
+		setType(name: string, type: string): void {
+			throw new Error("Not implemented.");
+		}
+	};
 }


### PR DESCRIPTION
Related to #9

Updates the `AppMock` class in `__mocks__/obsidian/App.ts` to correctly implement the `App` interface from `obsidian`, addressing the issue with failing test suites due to the recent changes in the `obsidian.ts` mocks.
- Adds missing properties `internalPlugins`, `isMobile`, `getObsidianUrl`, and `metadataTypeManager` to the `AppMock` class to ensure it fully implements the `App` interface.
- Throws a "Not implemented" error for the newly added methods and properties, maintaining consistency with the existing mock implementation strategy.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lightningRalf/obsidian-excalidraw-plugin/issues/9?shareId=55841678-a81e-4790-bc82-098080d0afca).