### PR TITLE
Fix test suite errors

### DIFF
--- a/__mocks__/obsidian/App.ts
+++ b/__mocks__/obsidian/App.ts
@@ -1,4 +1,4 @@
-import type { App, FileManager, Keymap, MetadataCache, Scope, UserEvent, Vault, Workspace } from "obsidian";
+import type { App, FileManager, Keymap, MetadataCache, Scope, UserEvent, Vault, Workspace, TFile } from "obsidian";
 
 export class AppMock implements App {
 	get keymap(): Keymap {
@@ -31,9 +31,9 @@ export class AppMock implements App {
 	getObsidianUrl(file: TFile): string {
 		throw new Error("Not implemented.");
 	}
-	metadataTypeManager: {
+	metadataTypeManager = {
 		setType(name: string, type: string): void {
 			throw new Error("Not implemented.");
 		}
-	};
+	}
 }


### PR DESCRIPTION
Related to #11

Fixes type errors and syntax issues in `__mocks__/obsidian/App.ts` to ensure test suites run successfully.

- Imports `TFile` from `obsidian` to resolve the 'Cannot find name 'TFile'' error.
- Corrects the syntax for `metadataTypeManager` by changing it from a property declaration to a class field with an initializer, addressing the 'Property 'metadataTypeManager' has no initializer' error.
- Removes the erroneous semicolon at the end of the class declaration to fix the 'Declaration or statement expected' error.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lightningRalf/obsidian-excalidraw-plugin/issues/11?shareId=5d7cd435-222a-437d-8229-3186eabebbe0).