### PR TITLE
Fix ModalMock implementation to include setTitle and setContent

### DIFF
--- a/__mocks__/obsidian/Modal.ts
+++ b/__mocks__/obsidian/Modal.ts
@@ -31,4 +31,10 @@ export class ModalMock implements Modal {
 	onClose(): void {
 		throw new Error("Method not implemented.");
 	}
+	setTitle(title: string): void {
+		throw new Error("Method not implemented.");
+	}
+	setContent(content: string | HTMLElement): void {
+		throw new Error("Method not implemented.");
+	}
 }


### PR DESCRIPTION
Related to #13

Updates the `ModalMock` class to correctly implement the required `setTitle` and `setContent` methods as per the issue encountered during testing.
- Adds `setTitle` method that accepts a string parameter and returns void, addressing the TypeScript error regarding the missing implementation.
- Adds `setContent` method that accepts either a string or HTMLElement parameter and returns void, fulfilling the required properties for the `Modal` class implementation. 


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lightningRalf/obsidian-excalidraw-plugin/issues/13?shareId=0f203cfd-d62d-4a34-8045-22e46ed1889d).