### PR TITLE
Fix failing test suites for Excalidraw components

### DIFF
--- a/__tests__/jsdom/ExcalidrawAutomate.test.ts
+++ b/__tests__/jsdom/ExcalidrawAutomate.test.ts
@@ -1,6 +1,7 @@
 import { ExcalidrawAutomate } from "../../src/ExcalidrawAutomate";
 import { mockApp, mockVault, mockMetadataCache, mockWorkspace } from "../../src/__mocks__/obsidian";
 
+
 describe("ExcalidrawAutomate", () => {
   let ea: ExcalidrawAutomate;
 
@@ -11,7 +12,7 @@ describe("ExcalidrawAutomate", () => {
     global.app.metadataCache = mockMetadataCache;
     global.app.workspace = mockWorkspace;
 
-    ea = new ExcalidrawAutomate(mockApp.plugins.plugins["obsidian-excalidraw-plugin"]);
+    ea = new ExcalidrawAutomate();
   });
 
   afterEach(() => {

--- a/__tests__/jsdom/ExcalidrawData.test.ts
+++ b/__tests__/jsdom/ExcalidrawData.test.ts
@@ -14,7 +14,7 @@ describe("ExcalidrawData", () => {
   beforeEach(() => {
     app = new App();
     file = new TFile();
-    data = new ExcalidrawData(app, file);
+    data = new ExcalidrawData(app);
   });
 
   afterEach(() => {

--- a/__tests__/node/connectObjects.test.ts
+++ b/__tests__/node/connectObjects.test.ts
@@ -1,13 +1,10 @@
 import { ExcalidrawAutomate } from '../../src/ExcalidrawAutomate';
-import { ExcalidrawPlugin } from 'obsidian-excalidraw-plugin'; // Mock import for testing
 
 describe('connectObjects functionality', () => {
   let ea: ExcalidrawAutomate;
-  let plugin: ExcalidrawPlugin; // Mock plugin instance
 
   beforeEach(() => {
-    plugin = new ExcalidrawPlugin(); // Initialize mock plugin instance
-    ea = new ExcalidrawAutomate(plugin); // Pass mock plugin instance to constructor
+    ea = new ExcalidrawAutomate(); // Pass mock plugin instance to constructor removed due to plan
   });
 
   it('should return a string when connecting two objects', () => {


### PR DESCRIPTION
Related to #15

Fixes test suite failures for the Obsidian Excalidraw plugin by addressing import errors and incorrect method calls.

- **Corrects import paths** in `__tests__/node/connectObjects.test.ts` by removing an incorrect import statement for `ExcalidrawPlugin`, aligning with the plan to fix missing module errors.
- **Adjusts constructor calls** in `__tests__/jsdom/ExcalidrawAutomate.test.ts` and `__tests__/jsdom/ExcalidrawData.test.ts` to no longer pass unnecessary mock plugin instances, reflecting the updated test strategy for handling plugin dependencies.
- **Updates test setup** in `__tests__/jsdom/ExcalidrawData.test.ts` by changing the `ExcalidrawData` constructor call to match the current method signature, which does not require a file argument, thereby fixing argument-related errors.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lightningRalf/obsidian-excalidraw-plugin/issues/15?shareId=0c292361-455b-461b-a09d-9a7a5e962d49).