### PR TITLE
Refactor line height calculation in font size cycle

### DIFF
--- a/ea-scripts/Relative Font Size Cycle.md
+++ b/ea-scripts/Relative Font Size Cycle.md
@@ -6,10 +6,8 @@ const api = ea.getExcalidrawAPI();
 const st = api.getAppState();
 const zoom = st.zoom.value;
 const currentItemFontSize = st.currentItemFontSize;
-
 const fontsizes = FONTSIZES.map(s=>s/zoom);
 const els = ea.getViewSelectedElements().filter(el=>el.type === "text");
-
 const findClosestIndex = (val, list) => {
   let closestIndex = 0;
   let closestDifference = Math.abs(list[0] - val);
@@ -22,15 +20,13 @@ const findClosestIndex = (val, list) => {
   }
   return closestIndex;
 }
-
 ea.viewUpdateScene({appState:{currentItemFontSize: fontsizes[(findClosestIndex(currentItemFontSize, fontsizes)+1) % fontsizes.length] }});
-
 if(els.length>0) {
   ea.copyViewElementsToEAforEditing(els);
   ea.getElements().forEach(el=> {
     el.fontSize = fontsizes[(findClosestIndex(el.fontSize, fontsizes)+1) % fontsizes.length];
     const font = ExcalidrawLib.getFontString(el);
-    const lineHeight = ExcalidrawLib.getDefaultLineHeight(el.fontFamily);
+    const lineHeight = (typeof el.lineHeight === "number" && Number.isFinite(el.lineHeight)) ? el.lineHeight : 1.25;
     const {width, height, baseline} = ExcalidrawLib.measureText(el.originalText, font, lineHeight);
     el.width = width;
     el.height = height;
@@ -38,3 +34,4 @@ if(els.length>0) {
   });
   ea.addElementsToView();
 }
+


### PR DESCRIPTION
Updated line height calculation to handle non-finite values.

-- 
Script didnt work anymore. So Codex fixed it for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined text measurement accuracy with smarter line height handling. The system now intelligently utilizes actual line height values when available, with a reliable automatic fallback for edge cases. This ensures more consistent and accurate calculations for text width, height, and baseline positioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->